### PR TITLE
Add workaround about exports function

### DIFF
--- a/notify-amount-transferred/src/main.ts
+++ b/notify-amount-transferred/src/main.ts
@@ -1,9 +1,12 @@
 import {BillingFetcherViaGmail} from './billing';
-import {calculateAmountPerCapita} from './calc-amount';
 import {AppConfig} from './config';
 import {DefaultNotificationMessage} from './message';
 import {NotifierFactory} from './notify';
 import {ScriptPropertyStore} from './property';
+
+// Google Apps Script does not support ES modules
+// https://github.com/google/clasp/blob/master/docs/typescript.md#the-exports-declaration-workaround
+declare const calcAmount: typeof import('./calc-amount');
 
 function main() {
   // Initialize
@@ -13,7 +16,7 @@ function main() {
   // Calc
   const billing = new BillingFetcherViaGmail(config.sharedCreditBilling).fetch();
   const housingCost = config.housingCost.sum();
-  const amountPerCapita = calculateAmountPerCapita(housingCost, billing);
+  const amountPerCapita = calcAmount.calculateAmountPerCapita(housingCost, billing);
   const message = new DefaultNotificationMessage(housingCost, billing, amountPerCapita);
 
   // Notify


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it

![image](https://user-images.githubusercontent.com/26768112/155832793-ead35bf9-c58f-4e0d-8eed-d76766512b87.png)

```
ReferenceError: calc_amount_1 is not defined
```

This occurred because Google Apps Script does not support ES modules currently.  
See: https://github.com/google/clasp/blob/master/docs/typescript.md#modules-exports-and-imports

#### Description of changes

Add workaround.
See: https://github.com/google/clasp/blob/master/docs/typescript.md#the-exports-declaration-workaround

#### Supported Information
