### PR TITLE
Refactor notification message handling and improve LINE notifier integration

### DIFF
--- a/.github/workflows/notify-amount-transferred--test.yaml
+++ b/.github/workflows/notify-amount-transferred--test.yaml
@@ -36,19 +36,13 @@ jobs:
 
   fix:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          # update the pull request branch
-          ref: ${{ github.head_ref }}
-          token:  ${{ secrets.GHA_TOKEN }}
+      - uses: actions/checkout@v4
       - uses: aquaproj/aqua-installer@v1.2.0
         with:
           aqua_version: v1.38.0
-      - run: github-comment exec -- yarn install --frozen-lockfile
-      - run: github-comment exec -- yarn fix
+      - run: github-comment exec --token ${{ secrets.GITHUB_TOKEN }} -- yarn install --frozen-lockfile
+      - run: github-comment exec --token ${{ secrets.GITHUB_TOKEN }} -- yarn fix
       - uses: int128/update-generated-files-action@v2
 
   test:

--- a/notify-amount-transferred/src/message.ts
+++ b/notify-amount-transferred/src/message.ts
@@ -1,6 +1,7 @@
 export interface NotificationMessage {
   getSubject(): string;
   getBody(): string;
+  getCombinationOfSubjectAndBody(): string;
 }
 
 export class DefaultNotificationMessage implements NotificationMessage {
@@ -8,13 +9,9 @@ export class DefaultNotificationMessage implements NotificationMessage {
   private body: string;
 
   constructor(housingCost: number, billing: number, amountPerCapita: number) {
-    this.subject = `Amount to be transferred to the common account this month: ${amountPerCapita.toLocaleString()} yen`;
-    this.body = `
-- Rent: ${housingCost.toLocaleString()} yen
-- Shared credit card billing: ${billing.toLocaleString()} yen
-
-Please transfer ${amountPerCapita.toLocaleString()} yen per person to the common account.
-`;
+    const date = new Date();
+    this.subject = `${date.getFullYear()}年${date.getMonth() + 1}月分の共通口座への振込金額`;
+    this.body = `${billing.toLocaleString()} 円を共通口座に振り込んでください`;
   }
 
   getSubject(): string {
@@ -23,5 +20,10 @@ Please transfer ${amountPerCapita.toLocaleString()} yen per person to the common
 
   getBody(): string {
     return this.body;
+  }
+
+  getCombinationOfSubjectAndBody(): string {
+    return `${this.getSubject()}:
+    ${this.getBody()}`;
   }
 }

--- a/notify-amount-transferred/src/notify.ts
+++ b/notify-amount-transferred/src/notify.ts
@@ -1,5 +1,5 @@
-import {PropertyStore} from './property';
-import {NotificationMessage} from './message';
+import { PropertyStore } from './property';
+import { NotificationMessage } from './message';
 
 export class NotifierFactory {
   create(notificationMessage: NotificationMessage, props: PropertyStore): Notifier {
@@ -7,10 +7,14 @@ export class NotifierFactory {
     switch (provider) {
       case 'line': {
         const token = props.get('line-notify-token');
+        const recipient = props.get('line-notify-recipient');
         if (token == null) {
           throw Error('Failed to get line token');
         }
-        return new LINENotifier(token, notificationMessage);
+        if (recipient == null) {
+          throw Error('Failed to get line recipient');
+        }
+        return new LINENotifier(token, recipient, notificationMessage);
       }
       case 'email': {
         const recipients = props.get('email-recipients');
@@ -30,7 +34,7 @@ interface Notifier {
 }
 
 class MailNotifier implements Notifier {
-  constructor(private recipients: string[], private notificationMessage: NotificationMessage) {}
+  constructor(private recipients: string[], private notificationMessage: NotificationMessage) { }
 
   notify() {
     this.recipients.forEach((recipient) => {
@@ -44,19 +48,21 @@ class MailNotifier implements Notifier {
 }
 
 class LINENotifier implements Notifier {
-  constructor(private token: string, private notificationMessage: NotificationMessage) {}
+  constructor(private channelAccessToken: string, private recipient: string, private notificationMessage: NotificationMessage) { }
 
   notify() {
-    const formData = {
-      message: this.notificationMessage.getBody(),
+    const payload = {
+      to: this.recipient,
+      messages: [this.notificationMessage.getCombinationOfSubjectAndBody()],
     };
     const params: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
       method: 'post',
       headers: {
-        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.channelAccessToken}`,
       },
-      payload: formData,
+      payload: JSON.stringify(payload),
     };
-    UrlFetchApp.fetch('https://notify-api.line.me/api/notify', params);
+    UrlFetchApp.fetch('https://api.line.me/v2/bot/message/push', params);
   }
 }

--- a/notify-amount-transferred/src/notify.ts
+++ b/notify-amount-transferred/src/notify.ts
@@ -1,5 +1,5 @@
-import { PropertyStore } from './property';
-import { NotificationMessage } from './message';
+import {PropertyStore} from './property';
+import {NotificationMessage} from './message';
 
 export class NotifierFactory {
   create(notificationMessage: NotificationMessage, props: PropertyStore): Notifier {
@@ -34,7 +34,7 @@ interface Notifier {
 }
 
 class MailNotifier implements Notifier {
-  constructor(private recipients: string[], private notificationMessage: NotificationMessage) { }
+  constructor(private recipients: string[], private notificationMessage: NotificationMessage) {}
 
   notify() {
     this.recipients.forEach((recipient) => {
@@ -48,7 +48,11 @@ class MailNotifier implements Notifier {
 }
 
 class LINENotifier implements Notifier {
-  constructor(private channelAccessToken: string, private recipient: string, private notificationMessage: NotificationMessage) { }
+  constructor(
+    private channelAccessToken: string,
+    private recipient: string,
+    private notificationMessage: NotificationMessage
+  ) {}
 
   notify() {
     const payload = {


### PR DESCRIPTION
This pull request updates the notification system to improve the format and delivery of messages, especially for LINE notifications. The main changes include updating the message structure, supporting recipient specification for LINE notifications, and switching to the newer LINE Messaging API.

**Notification message improvements:**

* Updated the `DefaultNotificationMessage` to use a more concise and localized subject and body format, and added a new `getCombinationOfSubjectAndBody()` method for combined messaging. [[1]](diffhunk://#diff-bfa658abca1388cd1b5e051990e6ebe5c92107fe344a436e1cf3b8656039a598R4-R14) [[2]](diffhunk://#diff-bfa658abca1388cd1b5e051990e6ebe5c92107fe344a436e1cf3b8656039a598R24-R28)

**LINE notification enhancements:**

* Modified `NotifierFactory` to require and use a recipient for LINE notifications, throwing an error if not provided.
* Updated `LINENotifier` to accept a recipient and use the LINE Messaging API (`/v2/bot/message/push`) with a JSON payload, instead of the older Notify API. The notification now sends the combined subject and body as a single message.