### PR TITLE
chore: update packageRules in renovate.json5 to exclude ESLint and Prettier

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,5 +7,15 @@
       matchUpdateTypes: ["minor", "patch", "pin"],
       automerge: true,
     },
+    // These are managed under gts (https://github.com/google/gts)
+    {
+      "matchPackageNames": [
+        "eslint",
+        "prettier",
+        "@typescript-eslint/eslint-plugin",
+        "@typescript-eslint/parser"
+      ],
+      "enabled": false
+    }
   ],
 }


### PR DESCRIPTION
This pull request updates the `renovate.json5` configuration to improve dependency management. The main change is the explicit disabling of Renovate updates for certain linting and formatting packages, which are managed separately under the `gts` tool.

Dependency management configuration:

* Added a new rule to disable Renovate updates for `eslint`, `prettier`, `@typescript-eslint/eslint-plugin`, and `@typescript-eslint/parser`, clarifying that these are managed via `gts`.