### PR TITLE
bugfix: add step to generate .clasp-prod.json in deployment workflow

### DIFF
--- a/.github/workflows/notify-common-expense--deploy.yaml
+++ b/.github/workflows/notify-common-expense--deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: npm ci
       - name: Generate .clasp.json
         run: |
-          echo "{\"scriptId\":\"${{ secrets.CLASP_SCRIPT_ID }}\",\"rootDir\":\"dist\"}" > .clasp-prod.json
+          echo "{\"scriptId\":\"${{ secrets.NOTIFY_COMMON_EXPENSE_SCRIPT_ID }}\",\"rootDir\":\"dist\"}" > .clasp.json
       - run: |
           mkdir -p "${HOME}"
           echo '${{ secrets.CLASPRC_JSON }}' > "${HOME}/.clasprc.json"

--- a/.github/workflows/notify-common-expense--deploy.yaml
+++ b/.github/workflows/notify-common-expense--deploy.yaml
@@ -21,9 +21,10 @@ jobs:
         with:
           node-version: "22"
       - run: npm ci
+      - name: Generate .clasp.json
+        run: |
+          echo "{\"scriptId\":\"${{ secrets.CLASP_SCRIPT_ID }}\",\"rootDir\":\"dist\"}" > .clasp-prod.json
       - run: |
           mkdir -p "${HOME}"
           echo '${{ secrets.CLASPRC_JSON }}' > "${HOME}/.clasprc.json"
-        env:
-          CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
       - run: npm run deploy:prod


### PR DESCRIPTION
This pull request updates the deployment workflow for the Notify Common Expense project. The main change is the addition of a step to generate the `.clasp.json` configuration file during the deployment process, ensuring the correct script ID and root directory are set for Google Apps Script deployments.

Deployment workflow improvements:

* Added a step to generate the `.clasp.json` file with the appropriate `scriptId` and `rootDir` using secrets, streamlining the deployment for Google Apps Script (`.github/workflows/notify-common-expense--deploy.yaml`).