### PR TITLE
fix: correct output filename for clasp.json generation in deployment workflow

### DIFF
--- a/.github/workflows/notify-common-expense--deploy.yaml
+++ b/.github/workflows/notify-common-expense--deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: npm ci
       - name: Generate .clasp.json
         run: |
-          echo "{\"scriptId\":\"${{ secrets.NOTIFY_COMMON_EXPENSE_SCRIPT_ID }}\",\"rootDir\":\"dist\"}" > .clasp.json
+          echo "{\"scriptId\":\"${{ secrets.NOTIFY_COMMON_EXPENSE_SCRIPT_ID }}\",\"rootDir\":\"dist\"}" > .clasp-prod.json
       - run: |
           mkdir -p "${HOME}"
           echo '${{ secrets.CLASPRC_JSON }}' > "${HOME}/.clasprc.json"


### PR DESCRIPTION
This pull request makes a small change to the deployment workflow for the Notify Common Expense project. The output file for the clasp configuration has been renamed from `.clasp.json` to `.clasp-prod.json` to likely distinguish production settings.