### PR TITLE
feat: add logging for notification provider usage and error handling

### DIFF
--- a/notify-common-expense/src/billing.ts
+++ b/notify-common-expense/src/billing.ts
@@ -23,7 +23,7 @@ export class BillingFetcherViaGmail implements BillingFetcher {
   constructor(
     private config: CreditCardBilling,
     private gmail: GoogleAppsScript.Gmail.GmailApp = GmailApp
-  ) { }
+  ) {}
 
   fetch(): number {
     const query = `from:(${this.config.mailAddress}) subject:(${this.config.mailSubject})`;
@@ -44,7 +44,9 @@ export class BillingFetcherViaGmail implements BillingFetcher {
     if (messages.length === 0) {
       throw Error(`There are no messsage in email that match. query: ${query}`);
     }
-    console.info(`Found email from: ${messages[0].getFrom()}, subject: ${messages[0].getSubject()}`);
+    console.info(
+      `Found email from: ${messages[0].getFrom()}, subject: ${messages[0].getSubject()}`
+    );
 
     const found = messages[0].getBody().match(this.config.extractRegexp);
     if (found == null || found.length < 2) {

--- a/notify-common-expense/src/billing.ts
+++ b/notify-common-expense/src/billing.ts
@@ -23,7 +23,7 @@ export class BillingFetcherViaGmail implements BillingFetcher {
   constructor(
     private config: CreditCardBilling,
     private gmail: GoogleAppsScript.Gmail.GmailApp = GmailApp
-  ) {}
+  ) { }
 
   fetch(): number {
     const query = `from:(${this.config.mailAddress}) subject:(${this.config.mailSubject})`;
@@ -44,6 +44,7 @@ export class BillingFetcherViaGmail implements BillingFetcher {
     if (messages.length === 0) {
       throw Error(`There are no messsage in email that match. query: ${query}`);
     }
+    console.info(`Found email from: ${messages[0].getFrom()}, subject: ${messages[0].getSubject()}`);
 
     const found = messages[0].getBody().match(this.config.extractRegexp);
     if (found == null || found.length < 2) {
@@ -51,6 +52,8 @@ export class BillingFetcherViaGmail implements BillingFetcher {
     }
 
     const billing = Number(found[1].replace(/,/g, ''));
+
+    console.info(`Fetched billing amount: ${billing}`);
     return billing;
   }
 }

--- a/notify-common-expense/src/config.ts
+++ b/notify-common-expense/src/config.ts
@@ -60,7 +60,8 @@ class Notification {
 function getProperty(props: PropertyStore, key: string): string {
   const val = props.get(key);
   if (val == null) {
-    throw Error(`Not found key ${key} in propety store`);
+    console.error('Error occurred:', `Not found key ${key} in property store`);
+    throw Error(`Not found key ${key} in property store`);
   }
   return val;
 }

--- a/notify-common-expense/src/notify.ts
+++ b/notify-common-expense/src/notify.ts
@@ -34,6 +34,7 @@ export function createNotifier(
 
   switch (provider) {
     case 'line': {
+      console.info('Using LINE as notification provider');
       const token = props.get('line-notify-token');
       const recipient = props.get('line-notify-recipient');
       if (!token) {
@@ -47,6 +48,7 @@ export function createNotifier(
       return new LINENotifier(token, recipient, notificationMessage);
     }
     case 'email': {
+      console.info('Using Email as notification provider');
       const recipients = props.get('email-recipients');
       if (!recipients) {
         throw new Error('Email recipients are required but not found');
@@ -69,7 +71,7 @@ class MailNotifier implements Notifier {
   constructor(
     private readonly recipients: readonly string[],
     private readonly notificationMessage: NotificationMessage
-  ) {}
+  ) { }
 
   notify(): void {
     this.recipients.forEach(recipient => {
@@ -91,7 +93,7 @@ class LINENotifier implements Notifier {
     private readonly channelAccessToken: string,
     private readonly recipient: string,
     private readonly notificationMessage: NotificationMessage
-  ) {}
+  ) { }
 
   notify(): void {
     const payload = {
@@ -103,6 +105,7 @@ class LINENotifier implements Notifier {
         },
       ],
     };
+    console.info('Sending LINE notification with payload:', payload);
     const params: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
       method: 'post',
       headers: {

--- a/notify-common-expense/src/notify.ts
+++ b/notify-common-expense/src/notify.ts
@@ -71,7 +71,7 @@ class MailNotifier implements Notifier {
   constructor(
     private readonly recipients: readonly string[],
     private readonly notificationMessage: NotificationMessage
-  ) { }
+  ) {}
 
   notify(): void {
     this.recipients.forEach(recipient => {
@@ -93,7 +93,7 @@ class LINENotifier implements Notifier {
     private readonly channelAccessToken: string,
     private readonly recipient: string,
     private readonly notificationMessage: NotificationMessage
-  ) { }
+  ) {}
 
   notify(): void {
     const payload = {


### PR DESCRIPTION
This pull request introduces improved logging throughout the notification and billing fetching workflow to aid debugging and increase visibility into key actions and errors. The changes primarily add informative `console.info` and `console.error` statements at important steps in the code.

**Logging improvements:**

* Added logging to indicate which notification provider is being used (`LINE` or `Email`) in the `createNotifier` function in `notify-common-expense/src/notify.ts`. [[1]](diffhunk://#diff-315a4fc08609c8dc8e42a1210287e5ee7326651849ad7761e540685863108640R37) [[2]](diffhunk://#diff-315a4fc08609c8dc8e42a1210287e5ee7326651849ad7761e540685863108640R51)
* Added logging before sending a LINE notification to show the payload being sent in `LINENotifier` in `notify-common-expense/src/notify.ts`.
* Added logging to display the sender and subject of the matched email, and the fetched billing amount in `BillingFetcherViaGmail` in `notify-common-expense/src/billing.ts`.

**Error handling improvements:**

* Added an error log before throwing an error when a key is not found in the property store in `getProperty` in `notify-common-expense/src/config.ts`.