### PR TITLE
fix: update message count filter and improve error handling in BillingFetcherViaGmail

### DIFF
--- a/notify-common-expense/src/billing.ts
+++ b/notify-common-expense/src/billing.ts
@@ -23,14 +23,14 @@ export class BillingFetcherViaGmail implements BillingFetcher {
   constructor(
     private config: CreditCardBilling,
     private gmail: GoogleAppsScript.Gmail.GmailApp = GmailApp
-  ) {}
+  ) { }
 
   fetch(): number {
     const query = `from:(${this.config.mailAddress}) subject:(${this.config.mailSubject})`;
     const threads = this.gmail.search(query);
 
     const sorted = threads
-      .filter(t => t.getMessageCount() === 1)
+      .filter(t => t.getMessageCount() === 2)
       .sort(
         (a, b) =>
           b.getLastMessageDate().getUTCMilliseconds() -
@@ -40,15 +40,15 @@ export class BillingFetcherViaGmail implements BillingFetcher {
       throw Error(`There are no emails that match. query: ${query}`);
     }
 
-    const messages = sorted[0].getMessages();
-    if (messages.length === 0) {
-      throw Error(`There are no messsage in email that match. query: ${query}`);
+    const message = sorted[0].getMessages()[0];
+    if (!message) {
+      throw Error(`There are no messages in email that match. query: ${query}`);
     }
     console.info(
-      `Found email from: ${messages[0].getFrom()}, subject: ${messages[0].getSubject()}`
+      `Found email from: ${message.getFrom()}, subject: ${message.getSubject()}`
     );
 
-    const found = messages[0].getBody().match(this.config.extractRegexp);
+    const found = message.getBody().match(this.config.extractRegexp);
     if (found == null || found.length < 2) {
       throw Error('Failed to Parse billing amount');
     }

--- a/notify-common-expense/src/billing.ts
+++ b/notify-common-expense/src/billing.ts
@@ -23,7 +23,7 @@ export class BillingFetcherViaGmail implements BillingFetcher {
   constructor(
     private config: CreditCardBilling,
     private gmail: GoogleAppsScript.Gmail.GmailApp = GmailApp
-  ) { }
+  ) {}
 
   fetch(): number {
     const query = `from:(${this.config.mailAddress}) subject:(${this.config.mailSubject})`;


### PR DESCRIPTION
This pull request updates the logic for fetching billing information via Gmail by refining how emails are filtered and simplifying message handling. The changes ensure that only threads with exactly two messages are considered, and streamline the code for extracting billing details from the first message in the selected thread.

**Filtering and message handling improvements:**

* Changed the filter to only include Gmail threads with exactly two messages, instead of one, to better match the expected billing email format.
* Simplified message extraction by directly accessing the first message in the sorted thread, and updated error handling and logging to reflect this change.