### PR TITLE
feat: filter billing email by body identifier instead of thread count

### DIFF
--- a/notify-common-expense/src/billing.ts
+++ b/notify-common-expense/src/billing.ts
@@ -29,20 +29,31 @@ export class BillingFetcherViaGmail implements BillingFetcher {
     const query = `from:(${this.config.mailAddress}) subject:(${this.config.mailSubject})`;
     const threads = this.gmail.search(query);
 
-    const sorted = threads
-      .filter(t => t.getMessageCount() === 2)
-      .sort(
-        (a, b) =>
-          b.getLastMessageDate().getUTCMilliseconds() -
-          a.getLastMessageDate().getUTCMilliseconds()
-      );
+    const sorted = threads.sort(
+      (a, b) =>
+        b.getLastMessageDate().getUTCMilliseconds() -
+        a.getLastMessageDate().getUTCMilliseconds()
+    );
     if (sorted.length === 0) {
       throw Error(`There are no emails that match. query: ${query}`);
     }
 
-    const message = sorted[0].getMessages()[0];
+    let message: GoogleAppsScript.Gmail.GmailMessage | undefined;
+    for (const thread of sorted) {
+      const candidate = thread.getMessages()[0];
+      if (
+        candidate &&
+        candidate.getPlainBody().includes(this.config.bodyIdentifier)
+      ) {
+        message = candidate;
+        break;
+      }
+    }
+
     if (!message) {
-      throw Error(`There are no messages in email that match. query: ${query}`);
+      throw Error(
+        `No email matching bodyIdentifier "${this.config.bodyIdentifier}" found. query: ${query}`
+      );
     }
     console.info(
       `Found email from: ${message.getFrom()}, subject: ${message.getSubject()}`

--- a/notify-common-expense/src/config.ts
+++ b/notify-common-expense/src/config.ts
@@ -29,15 +29,18 @@ export class CreditCardBilling {
   readonly mailAddress: string;
   readonly mailSubject: string;
   readonly extractRegexp: RegExp;
+  readonly bodyIdentifier: string;
 
   constructor(props: PropertyStore) {
     const mailAddressKey = 'shared-credit-billing-mail-address';
     const mailSubjectKey = 'shared-credit-billing-mail-subject';
     const extractRegexpKey = 'shared-credit-billing-extract-regexp';
+    const bodyIdentifierKey = 'shared-credit-billing-body-identifier';
 
     this.mailAddress = getProperty(props, mailAddressKey);
     this.mailSubject = getProperty(props, mailSubjectKey);
     this.extractRegexp = new RegExp(getProperty(props, extractRegexpKey));
+    this.bodyIdentifier = getProperty(props, bodyIdentifierKey);
   }
 }
 


### PR DESCRIPTION
## 変更内容

メールスレッドのメッセージ数（2通）でフィルタしていた処理を廃止し、メール本文に特定の文字列（口座名など）が含まれるかで絞り込む方式に変更。

### 背景

2枚のクレジットカードそれぞれに請求メールが届くようになり、スレッドが繋がらなくなったため、従来のスレッド数フィルタが機能しなくなった。

### 変更点

- `billing.ts`: `getMessageCount() === 2` フィルタを削除し、`getPlainBody()` で `bodyIdentifier` を含むメッセージを選択するロジックに変更
- `config.ts`: `CreditCardBilling` に `bodyIdentifier` フィールドを追加（GASプロパティキー: `shared-credit-billing-body-identifier`）
